### PR TITLE
Resume hero group movement after PvE combat

### DIFF
--- a/functions/src/movement/createPveEvent.ts
+++ b/functions/src/movement/createPveEvent.ts
@@ -218,6 +218,9 @@ export async function createPveEvent(
 
 
     const combatRef = db.collection('combats').doc();
+
+    const enemyXpTotal = enemies.reduce((sum, e) => sum + (e.xp ?? 0), 0);
+
     await combatRef.set({
       groupId,
       eventId,
@@ -230,6 +233,9 @@ export async function createPveEvent(
       type: 'pve',
       enemies,
       heroes, // 💾 Store combat-ready hero snapshots
+      enemyXpTotal,
+      enemyCount: enemies.length,
+      enemyName: eventData.name ?? enemies[0]?.name ?? 'Enemy',
       heroActions: [],
       enemyActions: [],
       combatLog: [],


### PR DESCRIPTION
## Summary
- preserve queued steps when triggering combat
- delete scheduled arrival task and keep waypoints for resumption
- resume movement after combat with surviving heroes
- update hero states when movement continues
- track combat XP info when creating PvE events

## Testing
- `npm run build`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68657b8e479c832da91fd3974add8923